### PR TITLE
Disable linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,22 +10,23 @@ jobs:
   ##################
   # Verilator Lint #
   ##################
-  verilator_lint:
-    name: Verilator Lint
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
-      with:
-        python-version: 3.9
-    - name: Install requirements
-      run: pip install -r python-requirements.txt
-    - name: Install Verilator
-      run: |
-        echo 'deb http://download.opensuse.org/repositories/home:/phiwag:/edatools/xUbuntu_20.04/ /' | sudo tee /etc/apt/sources.list.d/home:phiwag:edatools.list
-        curl -fsSL https://download.opensuse.org/repositories/home:phiwag:edatools/xUbuntu_20.04/Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/home_phiwag_edatools.gpg > /dev/null
-        sudo apt update
-        sudo apt install verilator
-    - name: Run Lint
-      run: |
-        ./util/verilog-lint
+  # (tempoarily) disable verilog linting until Verilator v5.008 is available for GitHub
+  #verilator_lint:
+  #  name: Verilator Lint
+  #  runs-on: ubuntu-latest
+  #  steps:
+  #  - uses: actions/checkout@v2
+  #  - uses: actions/setup-python@v2
+  #    with:
+  #      python-version: 3.9
+  #  - name: Install requirements
+  #    run: pip install -r python-requirements.txt
+  #  - name: Install Verilator
+  #    run: |
+  #      echo 'deb http://download.opensuse.org/repositories/home:/phiwag:/edatools/xUbuntu_20.04/ /' | sudo tee /etc/apt/sources.list.d/home:phiwag:edatools.list
+  #      curl -fsSL https://download.opensuse.org/repositories/home:phiwag:edatools/xUbuntu_20.04/Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/home_phiwag_edatools.gpg > /dev/null
+  #     sudo apt update
+  #     sudo apt install verilator
+  #  - name: Run Lint
+  #    run: |
+  #      ./util/verilog-lint


### PR DESCRIPTION
Temporarily disable linting on pushes and PRs util Verilator v5.008 (or better) can be easily installed and runs.